### PR TITLE
Add tox support for testing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ansible

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+minversion = 1.4.2
+skipsdist = True
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+
+[testenv:venv]
+commands = {posargs}


### PR DESCRIPTION
This is the first step towards using tox to run testing for qradar. We
use this today for release jobs, and eventually linting and integration
jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>